### PR TITLE
Generate Pytest-Based Test Cases from Refactored Code

### DIFF
--- a/notebooks/streamlite_app.py
+++ b/notebooks/streamlite_app.py
@@ -14,6 +14,7 @@ from src.utils.token_utils import estimate_tokens
 from src.llm.groq_client import get_groq_client
 from src.llm.analyzer import analyze_large_code
 from src.llm.refactorer import refactor_large_code
+from src.llm.test_case_generator import generate_test_cases
 
 import sys
 import os
@@ -38,38 +39,38 @@ if url:
         st.code(content, language='python')
         client = get_groq_client()
 
-        col1, col2 = st.columns(2)
-
         # Button: Analyze Code
-        with col1:
-            if st.button("🔍 Analyze Code"):
-                st.session_state.analysis_result = analyze_large_code(client, content, st)
-
-            # Show previous analysis if available
-            if "analysis_result" in st.session_state:
-                st.markdown("### 🔍 Code Analysis")
-                st.markdown(st.session_state.analysis_result)
+        if st.button("🔍 Analyze Code"):
+            st.session_state.analysis_result = analyze_large_code(client, content, st)
+        # Show previous analysis if available
+        if "analysis_result" in st.session_state:
+            st.markdown("### 🔍 Code Analysis")
+            st.markdown(st.session_state.analysis_result)
 
         # Button: Refactor Code
-        with col2:
-            if st.button("🔧 Refactor Code"):
-                st.session_state.refactor_step = 1  # Enable version input
+        if st.button("🔧 Refactor Code"):
+            st.session_state.refactor_step = 1  # Enable version input
 
-            # Refactor step
-            if st.session_state.get("refactor_step") == 1:
-                python_version = st.text_input("🐍 Enter Python Version (e.g., python3.10)", key="version_input")
+        # Refactor step
+        if st.session_state.get("refactor_step") == 1:
+            python_version = st.text_input("🐍 Enter Python Version (e.g., python3.10)", key="version_input")
 
-                if st.button("✅ Start Refactoring"):
-                    if python_version.strip() == "":
-                        st.warning("Please enter a Python version.")
-                    else:
-                        st.session_state.refactor_result = refactor_large_code(client, content, st, python_version.strip())
-                        st.session_state.refactor_step = 0  # Reset step
+            if st.button("✅ Start Refactoring"):
+                if python_version.strip() == "":
+                    st.warning("Please enter a Python version.")
+                else:
+                    st.session_state.refactor_result = refactor_large_code(client, content, st, python_version.strip())
+                    st.session_state.refactor_step = 0  # Reset step
+        # Show previous refactor result if available
+        if "refactor_result" in st.session_state:
+            st.markdown("### 🔧 Refactored Code")
+            st.code(st.session_state.refactor_result, language="python")
+        
+            # Generating Test cases for Refactored code
+            if st.button("Generate Test Cases"):
+                st.session_state.generated_tese_tases = generate_test_cases(client, st.session_state.refactor_result)
+                st.code(st.session_state.generated_tese_tases, language = 'python')
 
-            # Show previous refactor result if available
-            if "refactor_result" in st.session_state:
-                st.markdown("### 🔧 Refactored Code")
-                st.code(st.session_state.refactor_result, language="python")
 
 
     except Exception as e:

--- a/src/llm/test_case_generator.py
+++ b/src/llm/test_case_generator.py
@@ -1,0 +1,26 @@
+
+
+def generate_test_cases(client, code_chunk):
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are an expert Python developer and test engineer. "
+                "Given a Python function, class, or script, generate well-structured unit test cases using the `pytest` framework. "
+                "Ensure all important behaviors are covered, and use meaningful test method names.\n\n"
+                "Only return raw test code without any explanations or markdown formatting."
+            )
+        },
+        {
+            "role": "user",
+            "content": f"Generate test cases for the following code:\n\n{code_chunk}"
+        }
+    ]
+    response = client.chat.completions.create(
+        model="llama-3.1-8b-instant",
+        messages=messages,
+        temperature=0.3,
+        top_p=0.9,
+        max_completion_tokens=2048*2
+    )
+    return response.choices[0].message.content.strip()


### PR DESCRIPTION
This PR introduces a new feature that enables automatic test case generation using the pytest framework for refactored code snippets. It enhances developer productivity by leveraging LLMs to quickly scaffold test coverage without manual effort.

### Summary of Changes

- Added a **"Generate Test Cases"** button to the Streamlit UI.
- Implemented logic to:
  - Use LLM (`llama-3.1-8b-instant`) to generate `pytest`-style test cases.
  - Store and display test cases in `st.session_state.generated_tese_tases`.
  - Ensure test generation only occurs after refactoring, using `refactor_result` as input.
  - Return clean Python test code (no extra explanations or markdown formatting).
